### PR TITLE
詳細ページ編集

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
-
-
+  before_action :authenticate_user!, except: [:index,:show]
 
   def index
     @items = Item.order("created_at DESC")
@@ -18,6 +16,10 @@ class ItemsController < ApplicationController
     else
       render :new
     end
+  end
+
+  def show
+    @item = Item.find(params[:id])
   end
 
   private

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,6 +8,7 @@ class Item < ApplicationRecord
   belongs_to :status
   has_one_attached :image
 
+
   validates :name, presence: true
   validates :explanation, presence: true
   validates :category_id, numericality: { other_than: 1 , message: "can't be blank"} 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,45 +129,44 @@
 
 
     <ul class='item-lists'>
+      <% @items.each do |item| %>
+        <li class='list'>
+          <%= link_to item_path(item.id) do %>
+            <div class='item-img-content'>
+              <%= image_tag item.image, class: "item-img" %>
 
-        <% @items.each do |item| %>
-          <li class='list'>
-            <%= link_to "#" do %>
-              <div class='item-img-content'>
-                <%= image_tag item.image, class: "item-img" %>
-
-                <%# 商品が売れていればsold outを表示しましょう %>
-                <div class='sold-out'>
-                  <span>Sold Out!!</span>
-                </div>
-                <%# //商品が売れていればsold outを表示しましょう %>
-
+              <%# 商品が売れていればsold outを表示しましょう %>
+              <div class='sold-out'>
+                <span>Sold Out!!</span>
               </div>
-              <div class='item-info'>
-                <h3 class='item-name'>
-                  <%= item.name %>
-                </h3>
+              <%# //商品が売れていればsold outを表示しましょう %>
 
-                <div class='item-price'>
-                  <span><%= item.price %>円<br>
-                    <% if item.shipping_source_id == 2 %>
-                      着払い（購入者負担）
-                    <% elsif item.shipping_source_id == 3 %>
-                      送料込み（出品者負担）
-                    <% end %>
-                  </span>
+            </div>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                <%= item.name %>
+              </h3>
 
-                  <div class='star-btn'>
-                    <%= image_tag "star.png", class:"star-icon" %>
-                    <span class='star-count'>0</span>
-                  </div>
+              <div class='item-price'>
+                <span><%= item.price %>円<br>
+                  <% if item.shipping_source_id == 2 %>
+                    着払い（購入者負担）
+                  <% elsif item.shipping_source_id == 3 %>
+                    送料込み（出品者負担）
+                  <% end %>
+                </span>
+
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
                 </div>
               </div>
-            <% end %>
-          </li>
-        <% end %>
+            </div>
+          <% end %>
+        </li>
+      <% end %>
 
-      <% if @items = [] %>
+      <% if @items == [] %>
         <li class='list'>
           <%= link_to '#' do %>
             <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -16,25 +16,30 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>円
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <% if @item.shipping_source_id == 2 %>
+          着払い（購入者負担）
+        <% elsif @item.shipping_source_id == 3 %>
+          送料込み（出品者負担）
+        <% end %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      <p class="or-text">or</p>
+      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <% end %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+    <% if user_signed_in? && current_user.id != @item.user_id %>
+      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+    <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
@@ -43,27 +48,49 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value">
+            <%= @item.user.nick_name %>
+          </td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value">
+            <%= @item.category.name %>
+          </td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value">
+            <%= @item.status.name %>
+          </td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value">
+            <% if @item.shipping_source_id == 2 %>
+              着払い（購入者負担）
+            <% elsif @item.shipping_source_id == 3 %>
+              送料込み（出品者負担）
+            <% end %>
+          </td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value">
+            <%= @item.area.name %>
+          </td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value">
+            <% if @item.mailing_date_id == 2 %>
+              １〜２日で発送
+            <% elsif @item.mailing_date_id == 3 %>
+              ２〜３日で発送
+            <% elsif @item.mailing_date_id == 4 %>
+              ４〜７日で発送
+            <% end %>
+          </td>
         </tr>
       </tbody>
     </table>
@@ -102,9 +129,9 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
+
 </div>
 
 <%= render "shared/footer" %>


### PR DESCRIPTION
What  
商品詳細表示機能を実装した  
Why  
アプリに商品の詳細について記載したページを表示する機能を追加するため

ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/69ba9e1e7305d723bd35877b7fd18a89

ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/7baa961c5b94aab8062778d805576c61

ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画
現段階で商品購入機能の実装が済んでいないため、未実装

ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/f2e7bece062b015353d894cd8edcd746